### PR TITLE
closing environment when done

### DIFF
--- a/src/rl_framework/agent/stable_baselines.py
+++ b/src/rl_framework/agent/stable_baselines.py
@@ -159,6 +159,8 @@ class StableBaselinesAgent(Agent):
         callback_list = CallbackList([SavingCallback(self), LoggingCallback()])
         self.algorithm.learn(total_timesteps=total_timesteps, callback=callback_list)
 
+        vectorized_environment.close()
+
     def to_vectorized_env(self, env_fns) -> VecEnv:
         return SubprocVecEnv(env_fns)
 


### PR DESCRIPTION
The environment should be closed in the scope is has been created.
https://stable-baselines3.readthedocs.io/en/master/guide/examples.html

However in this case its a bit more tricky since the sub environments are from outside the scope, and closing them may also be unexpected.

Closing outside is not possible since the vec environment may clone the sub environment.