### PR TITLE
Added training callbacks to all imitation algorithms

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "reinforcement-learning-framework"
-version = "0.6.1"
+version = "0.6.2"
 description = "An easy-to-read Reinforcement Learning (RL) framework. Provides standardized interfaces and implementations to various Reinforcement Learning methods and environments. Also this is the main place to start your journey with Reinforcement Learning and learn from tutorials and examples."
 homepage = "https://github.com/alexander-zap/reinforcement-learning-framework"
 authors = ["Alexander Zap"]

--- a/src/rl_framework/agent/imitation/imitation/imitation.py
+++ b/src/rl_framework/agent/imitation/imitation/imitation.py
@@ -10,6 +10,7 @@ from imitation.algorithms.base import DemonstrationAlgorithm
 from imitation.algorithms.bc import BC
 from imitation.algorithms.density import DensityAlgorithm
 from imitation.algorithms.sqil import SQIL
+from stable_baselines3.common.callbacks import CallbackList
 from stable_baselines3.common.env_util import SubprocVecEnv
 from stable_baselines3.common.monitor import Monitor
 from stable_baselines3.common.vec_env.base_vec_env import VecEnv
@@ -24,7 +25,7 @@ from rl_framework.agent.imitation.imitation.imitation_algorithm_wrappers import 
     SQILAlgorithmWrapper,
 )
 from rl_framework.agent.imitation.imitation_learning_agent import ILAgent
-from rl_framework.util import Connector
+from rl_framework.util import Connector, LoggingCallback, SavingCallback
 
 IMITATION_ALGORITHM_WRAPPER_REGISTRY = {
     BC: BCAlgorithmWrapper,
@@ -115,7 +116,10 @@ class ImitationAgent(ILAgent):
         else:
             self.algorithm.set_demonstrations(trajectories)
 
-        self.algorithm_wrapper.train(self.algorithm, total_timesteps)
+        callback_list = CallbackList(
+            [SavingCallback(self, connector, training_environments[0]), LoggingCallback(connector)]
+        )
+        self.algorithm_wrapper.train(self.algorithm, total_timesteps, callback_list)
 
         self.algorithm_policy = self.algorithm.policy
 

--- a/src/rl_framework/agent/imitation/imitation/imitation_algorithm_wrappers.py
+++ b/src/rl_framework/agent/imitation/imitation/imitation_algorithm_wrappers.py
@@ -118,7 +118,6 @@ class BCAlgorithmWrapper(AlgorithmWrapper):
                 saving_callback = copy.copy(callback)
 
                 def save(batch_number):
-                    on_batch_end_counter[save] += 1
                     saving_callback.num_timesteps = algorithm.batch_size * batch_number
                     saving_callback._on_step()
 
@@ -133,7 +132,6 @@ class BCAlgorithmWrapper(AlgorithmWrapper):
                 )
 
                 def log(batch_number):
-                    on_batch_end_counter[log] += 1
                     if on_batch_end_counter[log] % logging_interval == 0:
                         rollout_stats = compute_rollout_stats(algorithm.policy, algorithm.rng)
                         logging_callback.connector.log_value(
@@ -146,6 +144,7 @@ class BCAlgorithmWrapper(AlgorithmWrapper):
 
         def on_batch_end():
             for func in on_batch_end_functions:
+                on_batch_end_counter[func] += 1
                 func(on_batch_end_counter[func])
 
         algorithm.train(n_batches=math.ceil(total_timesteps / algorithm.batch_size), on_batch_end=on_batch_end)

--- a/src/rl_framework/util/__init__.py
+++ b/src/rl_framework/util/__init__.py
@@ -10,4 +10,9 @@ from .saving_and_loading import (
     HuggingFaceUploadConfig,
     UploadConfig,
 )
+from .training_callbacks import (
+    LoggingCallback,
+    SavingCallback,
+    add_callbacks_to_callback,
+)
 from .video_recording import record_video

--- a/src/rl_framework/util/training_callbacks.py
+++ b/src/rl_framework/util/training_callbacks.py
@@ -1,0 +1,81 @@
+import numpy as np
+from stable_baselines3.common.callbacks import BaseCallback, CallbackList
+
+
+def add_callbacks_to_callback(callbacks_to_add: CallbackList, callback_to_be_added_to: BaseCallback):
+    if callback_to_be_added_to is None:
+        callback_to_be_added_to = CallbackList([])
+    elif not isinstance(callback_to_be_added_to, CallbackList):
+        callback_to_be_added_to = CallbackList([callback_to_be_added_to])
+
+    for callback in callbacks_to_add.callbacks:
+        if callback not in callback_to_be_added_to.callbacks:
+            callback_to_be_added_to.callbacks.append(callback)
+
+
+class LoggingCallback(BaseCallback):
+    """
+    A custom callback that logs episode rewards after every done episode.
+    """
+
+    def __init__(self, connector, verbose=0):
+        """
+        Args:
+            verbose: Verbosity level: 0 for no output, 1 for info messages, 2 for debug messages
+        """
+        super().__init__(verbose)
+        self.connector = connector
+        self.episode_reward = None
+
+    def _on_step(self) -> bool:
+        """
+        This method will be called by the model after each call to `env.step()`.
+        If the callback returns False, training is aborted early.
+        """
+        if self.episode_reward is None:
+            self.episode_reward = self.locals["rewards"]
+        else:
+            self.episode_reward += self.locals["rewards"]
+
+        done_indices = np.where(self.locals["dones"] == True)[0]
+        if done_indices.size != 0:
+            for done_index in done_indices:
+                if not self.locals["infos"][done_index].get("discard", False):
+                    self.connector.log_value(self.num_timesteps, self.episode_reward[done_index], "Episode reward")
+                    self.episode_reward[done_index] = 0
+
+        return True
+
+
+class SavingCallback(BaseCallback):
+    """
+    A custom callback which uploads the agent to the connector after every `checkpoint_frequency` steps.
+    """
+
+    def __init__(self, agent, connector, evaluation_environment, checkpoint_frequency=50000, verbose=0):
+        """
+        Args:
+            checkpoint_frequency: After how many steps a checkpoint should be saved to the connector.
+            verbose: Verbosity level: 0 for no output, 1 for info messages, 2 for debug messages
+        """
+        super().__init__(verbose)
+        self.agent = agent
+        self.connector = connector
+        self.evaluation_environment = evaluation_environment
+        self.checkpoint_frequency = checkpoint_frequency
+        self.next_upload = checkpoint_frequency
+
+    def _on_step(self) -> bool:
+        """
+        This method will be called by the model after each call to `env.step()`.
+        If the callback returns False, training is aborted early.
+        """
+        if self.num_timesteps > self.next_upload:
+            self.connector.upload(
+                agent=self.agent,
+                evaluation_environment=self.evaluation_environment,
+                checkpoint_id=self.num_timesteps,
+            )
+            self.next_upload = self.num_timesteps + self.checkpoint_frequency
+
+        return True


### PR DESCRIPTION
- callback implementation shared between reinforcement and imitation learning algorithms (AIRL, GAIL, SQIL and Density)
- behavioral cloning (BC) requires a workaround implementation, since no SB3 algorithm is used for training
- activated built-in tensorboard logs where appropriate (for ClearML)
- added type hints to algorithm wrapper `build_algorithm` and `train`
- fixed SQIL to work with generators