### PR TITLE
Split of agent evaluation and agent upload

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "reinforcement-learning-framework"
-version = "0.6.3"
+version = "0.6.4"
 description = "An easy-to-read Reinforcement Learning (RL) framework. Provides standardized interfaces and implementations to various Reinforcement Learning methods and environments. Also this is the main place to start your journey with Reinforcement Learning and learn from tutorials and examples."
 homepage = "https://github.com/alexander-zap/reinforcement-learning-framework"
 authors = ["Alexander Zap"]

--- a/src/rl_framework/agent/base_agent.py
+++ b/src/rl_framework/agent/base_agent.py
@@ -80,25 +80,19 @@ class Agent(ABC):
     def load_from_file(self, file_path: Path, algorithm_parameters: Optional[Dict], *args, **kwargs) -> None:
         raise NotImplementedError
 
-    def upload(
-        self,
-        connector: Connector,
-        video_recording_environment: gym.Env,
-        variable_values_to_log: Dict,
-    ) -> None:
+    def upload(self, connector: Connector, video_recording_environment: Optional[gym.Env]) -> None:
         """
         Evaluate and upload the decision-making agent to the connector.
             Additional option: Generate a video of the agent interacting with the environment.
 
         Args:
             connector (Connector): Connector for uploading.
-            video_recording_environment (gym.Env): Env used for clip creation before upload.
-            variable_values_to_log (Dict): Variable name and values to be uploaded and logged, e.g. evaluation metrics.
+            video_recording_environment (gym.Env): Environment used for clip creation before upload.
+                Optional. If not provided, no video will be recorded.
         """
         connector.upload(
             agent=self,
             video_recording_environment=video_recording_environment,
-            variable_values_to_log=variable_values_to_log,
         )
 
     def download(

--- a/src/rl_framework/agent/imitation/imitation/imitation_algorithm_wrappers.py
+++ b/src/rl_framework/agent/imitation/imitation/imitation_algorithm_wrappers.py
@@ -134,7 +134,7 @@ class BCAlgorithmWrapper(AlgorithmWrapper):
                 def log(batch_number):
                     if on_batch_end_counter[log] % logging_interval == 0:
                         rollout_stats = compute_rollout_stats(algorithm.policy, algorithm.rng)
-                        logging_callback.connector.log_value(
+                        logging_callback.connector.log_value_with_timestep(
                             algorithm.batch_size * batch_number, rollout_stats["return_mean"], "Episode reward"
                         )
 

--- a/src/rl_framework/agent/reinforcement/custom_algorithms/q_learning.py
+++ b/src/rl_framework/agent/reinforcement/custom_algorithms/q_learning.py
@@ -183,8 +183,8 @@ class QLearning(CustomAlgorithm):
                     )
 
                     if connector:
-                        connector.log_value(current_timestep, episode_reward, "Episode reward")
-                        connector.log_value(current_timestep, self.epsilon, "Epsilon")
+                        connector.log_value_with_timestep(current_timestep, episode_reward, "Episode reward")
+                        connector.log_value_with_timestep(current_timestep, self.epsilon, "Epsilon")
 
         tqdm_progress_bar.close()
 

--- a/src/rl_framework/util/connector/dummy_connector.py
+++ b/src/rl_framework/util/connector/dummy_connector.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Optional
 
 import gymnasium as gym
 
@@ -14,7 +14,6 @@ class DummyConnector(Connector):
         self,
         agent,
         video_recording_environment: Optional[gym.Env] = None,
-        variable_values_to_log: Optional[Dict] = None,
         checkpoint_id: Optional[int] = None,
         *args,
         **kwargs,

--- a/src/rl_framework/util/training_callbacks.py
+++ b/src/rl_framework/util/training_callbacks.py
@@ -41,7 +41,9 @@ class LoggingCallback(BaseCallback):
         if done_indices.size != 0:
             for done_index in done_indices:
                 if not self.locals["infos"][done_index].get("discard", False):
-                    self.connector.log_value(self.num_timesteps, self.episode_reward[done_index], "Episode reward")
+                    self.connector.log_value_with_timestep(
+                        self.num_timesteps, self.episode_reward[done_index], "Episode reward"
+                    )
                     self.episode_reward[done_index] = 0
 
         return True


### PR DESCRIPTION
- logging of values (e.g., final evaluation metrics) split from agent upload method
- added `upload` variable to connector upload config
- made passing of video_recording_environment in agent optional