### PR TITLE
Improved logging in Behavioral Cloning algorithm

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,6 @@ repos:
       - id: check-toml
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      - id: check-added-large-files
       - id: check-builtin-literals
       - id: check-merge-conflict
       - id: detect-private-key

--- a/data/cartpole_rollout/dataset_info.json
+++ b/data/cartpole_rollout/dataset_info.json
@@ -1,0 +1,43 @@
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "obs": {
+      "feature": {
+        "feature": {
+          "dtype": "float32",
+          "_type": "Value"
+        },
+        "_type": "Sequence"
+      },
+      "_type": "Sequence"
+    },
+    "acts": {
+      "feature": {
+        "dtype": "int64",
+        "_type": "Value"
+      },
+      "_type": "Sequence"
+    },
+    "infos": {
+      "feature": {
+        "dtype": "string",
+        "_type": "Value"
+      },
+      "_type": "Sequence"
+    },
+    "terminal": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "rews": {
+      "feature": {
+        "dtype": "float64",
+        "_type": "Value"
+      },
+      "_type": "Sequence"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/data/cartpole_rollout/state.json
+++ b/data/cartpole_rollout/state.json
@@ -4,7 +4,7 @@
       "filename": "data-00000-of-00001.arrow"
     }
   ],
-  "_fingerprint": "ccac82e0965ac06e",
+  "_fingerprint": "6f72cbba1271a941",
   "_format_columns": null,
   "_format_kwargs": {},
   "_format_type": null,

--- a/data/cartpole_rollout/state.json
+++ b/data/cartpole_rollout/state.json
@@ -1,0 +1,13 @@
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "ccac82e0965ac06e",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/exploration/train_il_agent.py
+++ b/exploration/train_il_agent.py
@@ -3,7 +3,7 @@ import os
 import gymnasium as gym
 import numpy as np
 from clearml import Task
-from imitation.algorithms.adversarial.gail import GAIL
+from imitation.algorithms.bc import BC
 from imitation.data import rollout, serialize
 from imitation.data.wrappers import RolloutInfoWrapper
 from imitation.policies.serialize import load_policy
@@ -53,7 +53,7 @@ def create_and_save_trajectories_dataset(env, timesteps, trajectories_dataset_pa
 
 PARALLEL_ENVIRONMENTS = 8
 DOWNLOAD_EXISTING_AGENT = False
-TRAJECTORIES_PATH = "../data/test_rollouts"
+TRAJECTORIES_PATH = "../data/cartpole_rollout"
 
 N_TRAINING_TIMESTEPS = 200000
 N_EVALUATION_EPISODES = 10
@@ -77,7 +77,7 @@ if __name__ == "__main__":
     )
 
     # Create new agent
-    agent = ImitationAgent(algorithm_class=GAIL, algorithm_parameters={})
+    agent = ImitationAgent(algorithm_class=BC, algorithm_parameters={})
 
     if DOWNLOAD_EXISTING_AGENT:
         # Download existing agent from repository


### PR DESCRIPTION
BC now logs all training and rollout metrics if LoggingCallback is requested.

Additionally provided example dataset for CartPole-v1 (reproducable train_il.py).