### PR TITLE
BC now uses validation data for logging callback

### DIFF
--- a/exploration/train_il_agent.py
+++ b/exploration/train_il_agent.py
@@ -77,7 +77,7 @@ if __name__ == "__main__":
     )
 
     # Create new agent
-    agent = ImitationAgent(algorithm_class=BC, algorithm_parameters={})
+    agent = ImitationAgent(algorithm_class=BC, algorithm_parameters={"validation_fraction": 0.1})
 
     if DOWNLOAD_EXISTING_AGENT:
         # Download existing agent from repository

--- a/src/rl_framework/util/__init__.py
+++ b/src/rl_framework/util/__init__.py
@@ -15,4 +15,5 @@ from .training_callbacks import (
     SavingCallback,
     add_callbacks_to_callback,
 )
+from .types import SizedGenerator
 from .video_recording import record_video

--- a/src/rl_framework/util/types.py
+++ b/src/rl_framework/util/types.py
@@ -1,0 +1,29 @@
+from typing import Generator, Generic, Sized, TypeVar
+
+T = TypeVar("T")
+
+
+class SizedGenerator(Generator[T, None, None], Sized, Generic[T]):
+    def __init__(self, generator: Generator, size: int):
+        self.generator = generator
+        self.size = size
+
+    def __len__(self):
+        return self.size
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        next_element = next(self.generator)
+        self.size -= 1
+        return next_element
+
+    def send(self, value):
+        return self.generator.send(value)
+
+    def throw(self, typ, val=None, tb=None):
+        return self.generator.throw(typ, val, tb)
+
+    def close(self):
+        return self.generator.close()


### PR DESCRIPTION
- "validation_fraction" parameter now can be provided which controls the percentage of episodes being held-out for validation
- held-out validation data is used in the on_epoch_end callback and logs all loss metrics for this held-out data
- introduced SizedGenerator class to provide a length attribute to generators where the amount of data that will be generated is known