### PR TITLE
Log reset_infos to connectors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "reinforcement-learning-framework"
-version = "0.9.10"
+version = "0.9.11"
 description = "An easy-to-read Reinforcement Learning (RL) framework. Provides standardized interfaces and implementations to various Reinforcement Learning methods and utilities."
 homepage = "https://github.com/alexander-zap/reinforcement-learning-framework"
 authors = ["Alexander Zap"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "reinforcement-learning-framework"
-version = "0.9.11"
+version = "0.9.12"
 description = "An easy-to-read Reinforcement Learning (RL) framework. Provides standardized interfaces and implementations to various Reinforcement Learning methods and utilities."
 homepage = "https://github.com/alexander-zap/reinforcement-learning-framework"
 authors = ["Alexander Zap"]
@@ -45,7 +45,7 @@ imitation = "^1.0.0"
 pyarrow-hotfix = "^0.6"
 pyarrow = "<=20.0.0"  # right now there is a bug with 21.0
 d3rlpy = "^2.6"
-async-gym-agents = "^0.2.4"
+async-gym-agents = "^0.2.5"
 supersuit = "^3.9.3"
 onnx = "^1.15.0"
 

--- a/src/rl_framework/agent/reinforcement/stable_baselines.py
+++ b/src/rl_framework/agent/reinforcement/stable_baselines.py
@@ -26,6 +26,7 @@ from rl_framework.util import (
     Environment,
     FeaturesExtractor,
     LoggingCallback,
+    ResetInfoCallback,
     SavingCallback,
     get_sb3_policy_kwargs_for_features_extractor,
     wrap_environment_with_features_extractor_preprocessor,
@@ -233,7 +234,9 @@ class StableBaselinesAgent(RLAgent):
                     else self.algorithm_class.load(**algorithm_kwargs, device=device)
                 )
 
-        callback_list = CallbackList([SavingCallback(self, connector), LoggingCallback(connector)])
+        callback_list = CallbackList(
+            [SavingCallback(self, connector), LoggingCallback(connector), ResetInfoCallback(connector)]
+        )
         self.algorithm.learn(total_timesteps=total_timesteps, callback=callback_list)
         vectorized_environment.close()
 

--- a/src/rl_framework/util/__init__.py
+++ b/src/rl_framework/util/__init__.py
@@ -19,6 +19,7 @@ from .features_extractor_utils import (
 )
 from .sb3_training_callbacks import (
     LoggingCallback,
+    ResetInfoCallback,
     SavingCallback,
     add_callbacks_to_callback,
 )

--- a/src/rl_framework/util/connector/base_connector.py
+++ b/src/rl_framework/util/connector/base_connector.py
@@ -79,6 +79,17 @@ class Connector(ABC):
         self.histogram_sequences_to_log: Dict[Text, List[Tuple]] = defaultdict(list)
         self.value_sequences_to_log: Dict[Text, List[Tuple]] = defaultdict(list)
         self.values_to_log: Dict[Text, SupportsFloat] = {}
+        self.dicts_to_log: Dict[Text, dict] = {}
+
+    def log_dict(self, dict_to_log: dict, dict_name: Text) -> None:
+        """
+        Log a dictionary to the ClearML task, which appears in the "Artifacts" section of the ClearML experiment page.
+
+        Args:
+            dict_to_log: Dictionary of values to log (e.g., {"game_version": 1.0, "num_sensors": 10})
+            dict_name: Name of the dictionary (e.g., "game settings")
+        """
+        self.dicts_to_log[dict_name] = dict_to_log
 
     def log_histogram_with_timestep(
         self, timestep: int, histogram_values: List[SupportsFloat], histogram_name: Text

--- a/src/rl_framework/util/connector/clearml_connector.py
+++ b/src/rl_framework/util/connector/clearml_connector.py
@@ -64,6 +64,17 @@ class ClearMLConnector(Connector):
 
         self.task.add_tags(list(self.upload_config.task_tags))
 
+    def log_dict(self, dict_to_log: dict, dict_name: Text) -> None:
+        """
+        Log a dictionary to the ClearML task, which appears in the "Artifacts" section of the ClearML experiment page.
+
+        Args:
+            dict_to_log: Dictionary of values to log (e.g., {"game_version": 1.0, "num_sensors": 10})
+            dict_name: Name of the dictionary (e.g., "game settings")
+        """
+        super().log_dict(dict_to_log, dict_name)
+        self.task.connect_configuration(dict_to_log, name=dict_name)
+
     def log_histogram_with_timestep(
         self, timestep: int, histogram_values: List[SupportsFloat], histogram_name: Text
     ) -> None:

--- a/src/rl_framework/util/connector/hugging_face_connector.py
+++ b/src/rl_framework/util/connector/hugging_face_connector.py
@@ -145,6 +145,8 @@ class HuggingFaceConnector(Connector):
                 json.dump(self.value_sequences_to_log, outfile)
             with open(repo_local_path / "logged_histograms.json", "w") as outfile:
                 json.dump(self.histogram_sequences_to_log, outfile)
+            with open(repo_local_path / "logged_dicts.json", "w") as outfile:
+                json.dump(self.dicts_to_log, outfile)
 
             # Step 5: Create a system info file
             with open(repo_local_path / "system.json", "w") as outfile:

--- a/src/rl_framework/util/sb3_training_callbacks.py
+++ b/src/rl_framework/util/sb3_training_callbacks.py
@@ -231,3 +231,51 @@ class ExperimentPruningCallback(BaseCallback):
                 return False
 
         return True
+
+
+class ResetInfoCallback(BaseCallback):
+    """
+    A custom callback that logs after every reset the reset_infos dict..
+    """
+
+    def __init__(self, connector, verbose=0):
+        """
+        Args:
+            verbose: Verbosity level: 0 for no output, 1 for info messages, 2 for debug messages
+        """
+        super().__init__(verbose)
+        self.connector = connector
+        # Tracking episode number for each agent (agent index -> episode count)
+        self.episode_counter: dict[str, int] = {}
+        # Tracking agents which have done a first step (list of agent indices)
+        self.first_step_tracker: list[str] = []
+
+    def _on_step(self) -> bool:
+        """
+        This method will be called by the model after each call to `env.step()`.
+        If the callback returns False, training is aborted early.
+        """
+
+        # Write reset info at first step of first episode
+        for agent_index, reset_info in enumerate(self.locals["reset_infos"]):
+            if agent_index not in self.first_step_tracker:
+                self.episode_counter[agent_index] = 0
+                self.first_step_tracker.append(agent_index)
+                if reset_info is not None:
+                    self.connector.log_dict(
+                        self.locals["reset_infos"][agent_index],
+                        f"Reset Info - Agent {agent_index} - Episode {self.episode_counter.get(agent_index, 0)}",
+                    )
+
+        # Write reset info at each reset (when done=True, reset has already happened and reset_info is available)
+        done_indices = np.where(self.locals["dones"] == True)[0]
+        if done_indices.size != 0:
+            for done_index in done_indices:
+                self.episode_counter[done_index] = self.episode_counter.get(done_index, 0) + 1
+                if reset_info is not None:
+                    self.connector.log_dict(
+                        self.locals["reset_infos"][done_index],
+                        f"Reset Info - Agent {done_index} - Episode {self.episode_counter.get(done_index, 0)}",
+                    )
+
+        return True

--- a/src/rl_framework/util/sb3_training_callbacks.py
+++ b/src/rl_framework/util/sb3_training_callbacks.py
@@ -70,8 +70,11 @@ class LoggingCallback(BaseCallback):
                     if metric_name not in self.episode_step_metrics:
                         self.episode_step_metrics[metric_name] = [[] for _ in range(len(self.locals["infos"]))]
                     self.episode_step_metrics[metric_name][agent_index].append(float(value))
-                if key.startswith("meta_") and isinstance(value, dict):
-                    self.connector.log_dict(value, key)
+                if key.startswith("meta_"):
+                    if isinstance(value, dict):
+                        self.connector.log_dict(value, key)
+                    else:
+                        self.connector.log_dict({key: value}, key)
 
         done_indices = np.where(self.locals["dones"] == True)[0]
         if done_indices.size != 0:

--- a/src/rl_framework/util/sb3_training_callbacks.py
+++ b/src/rl_framework/util/sb3_training_callbacks.py
@@ -261,7 +261,7 @@ class ResetInfoCallback(BaseCallback):
             if agent_index not in self.first_step_tracker:
                 self.episode_counter[agent_index] = 0
                 self.first_step_tracker.append(agent_index)
-                if reset_info is not None:
+                if reset_info:
                     self.connector.log_dict(
                         self.locals["reset_infos"][agent_index],
                         f"Reset Info - Agent {agent_index} - Episode {self.episode_counter.get(agent_index, 0)}",
@@ -272,7 +272,7 @@ class ResetInfoCallback(BaseCallback):
         if done_indices.size != 0:
             for done_index in done_indices:
                 self.episode_counter[done_index] = self.episode_counter.get(done_index, 0) + 1
-                if reset_info is not None:
+                if reset_info:
                     self.connector.log_dict(
                         self.locals["reset_infos"][done_index],
                         f"Reset Info - Agent {done_index} - Episode {self.episode_counter.get(done_index, 0)}",

--- a/src/rl_framework/util/sb3_training_callbacks.py
+++ b/src/rl_framework/util/sb3_training_callbacks.py
@@ -70,6 +70,8 @@ class LoggingCallback(BaseCallback):
                     if metric_name not in self.episode_step_metrics:
                         self.episode_step_metrics[metric_name] = [[] for _ in range(len(self.locals["infos"]))]
                     self.episode_step_metrics[metric_name][agent_index].append(float(value))
+                if key.startswith("meta_") and isinstance(value, dict):
+                    self.connector.log_dict(value, key)
 
         done_indices = np.where(self.locals["dones"] == True)[0]
         if done_indices.size != 0:
@@ -263,7 +265,7 @@ class ResetInfoCallback(BaseCallback):
                 self.first_step_tracker.append(agent_index)
                 if reset_info:
                     self.connector.log_dict(
-                        self.locals["reset_infos"][agent_index],
+                        reset_info,
                         f"Reset Info - Agent {agent_index} - Episode {self.episode_counter.get(agent_index, 0)}",
                     )
 
@@ -272,9 +274,10 @@ class ResetInfoCallback(BaseCallback):
         if done_indices.size != 0:
             for done_index in done_indices:
                 self.episode_counter[done_index] = self.episode_counter.get(done_index, 0) + 1
+                reset_info = self.locals["reset_infos"][done_index]
                 if reset_info:
                     self.connector.log_dict(
-                        self.locals["reset_infos"][done_index],
+                        reset_info,
                         f"Reset Info - Agent {done_index} - Episode {self.episode_counter.get(done_index, 0)}",
                     )
 


### PR DESCRIPTION
- Added functionality which makes connectors able to log dicts
- ResetInfoCallback uploads reset_info at the beginning of each episode
- LoggingCallback uploads "meta_<metric>" infos as dict
