### PR TITLE
Configurable callbacks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "reinforcement-learning-framework"
-version = "0.9.15"
+version = "0.9.16"
 description = "An easy-to-read Reinforcement Learning (RL) framework. Provides standardized interfaces and implementations to various Reinforcement Learning methods and utilities."
 homepage = "https://github.com/alexander-zap/reinforcement-learning-framework"
 authors = ["Alexander Zap"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "reinforcement-learning-framework"
-version = "0.9.14"
+version = "0.9.15"
 description = "An easy-to-read Reinforcement Learning (RL) framework. Provides standardized interfaces and implementations to various Reinforcement Learning methods and utilities."
 homepage = "https://github.com/alexander-zap/reinforcement-learning-framework"
 authors = ["Alexander Zap"]

--- a/src/rl_framework/agent/base_agent.py
+++ b/src/rl_framework/agent/base_agent.py
@@ -172,8 +172,7 @@ class Agent(ABC):
                         observations, rewards, dones, infos = evaluation_environment.step(np.array(prev_actions))
 
                         actions = [
-                            self.choose_action(observation, deterministic=deterministic)
-                            for observation in prev_observations
+                            self.choose_action(observation, deterministic=deterministic) for observation in observations
                         ]
 
                         current_rewards += rewards

--- a/src/rl_framework/agent/reinforcement/stable_baselines.py
+++ b/src/rl_framework/agent/reinforcement/stable_baselines.py
@@ -238,7 +238,7 @@ class StableBaselinesAgent(RLAgent):
         callback_verbosity = self.callback_parameters.get("callback_verbosity", 0)
         checkpoint_frequency = self.callback_parameters.get("checkpoint_frequency", 500000)
         log_distributions = self.callback_parameters.get("log_distributions", False)
-        logging_frequency = self.callback_parameters.get("logging_frequency", 500000)
+        logging_frequency = self.callback_parameters.get("logging_frequency", 1)
 
         callback_list = CallbackList(
             [

--- a/src/rl_framework/agent/reinforcement/stable_baselines.py
+++ b/src/rl_framework/agent/reinforcement/stable_baselines.py
@@ -236,18 +236,20 @@ class StableBaselinesAgent(RLAgent):
                 )
 
         callback_verbosity = self.callback_parameters.get("callback_verbosity", 0)
-        checkpoint_frequency = self.callback_parameters.get("checkpoint_frequency", 500000)
-        log_distributions = self.callback_parameters.get("log_distributions", False)
-        logging_frequency = self.callback_parameters.get("logging_frequency", 1)
+        callback_saving_interval = self.callback_parameters.get("callback_saving_interval", 500000)
+        callback_logging_interval = self.callback_parameters.get("callback_logging_interval", 1)
+        callback_log_distributions = self.callback_parameters.get("callback_log_distributions", False)
         sb3_logging_interval = self.callback_parameters.get("sb3_logging_interval", 1)
 
         callback_list = CallbackList(
             [
                 SavingCallback(
-                    self, connector=connector, checkpoint_frequency=checkpoint_frequency, verbose=callback_verbosity
+                    self, connector=connector, checkpoint_frequency=callback_saving_interval, verbose=callback_verbosity
                 ),
                 LoggingCallback(
-                    connector=connector, logging_frequency=logging_frequency, log_distributions=log_distributions
+                    connector=connector,
+                    logging_frequency=callback_logging_interval,
+                    log_distributions=callback_log_distributions,
                 ),
                 ResetInfoCallback(connector=connector),
             ]

--- a/src/rl_framework/agent/reinforcement/stable_baselines.py
+++ b/src/rl_framework/agent/reinforcement/stable_baselines.py
@@ -64,6 +64,7 @@ class StableBaselinesAgent(RLAgent):
         super().__init__(algorithm_class, algorithm_parameters, features_extractor)
 
         self.algorithm_parameters = self._add_required_default_parameters(self.algorithm_parameters)
+        self.callback_parameters = self.algorithm_parameters.pop("callback_kwargs", {})
 
         additional_parameters = (
             {"_init_setup_model": False} if (getattr(self.algorithm_class, "_setup_model", None)) else {}
@@ -234,8 +235,21 @@ class StableBaselinesAgent(RLAgent):
                     else self.algorithm_class.load(**algorithm_kwargs, device=device)
                 )
 
+        callback_verbosity = self.callback_parameters.get("callback_verbosity", 0)
+        checkpoint_frequency = self.callback_parameters.get("checkpoint_frequency", 500000)
+        log_distributions = self.callback_parameters.get("log_distributions", False)
+        logging_frequency = self.callback_parameters.get("logging_frequency", 500000)
+
         callback_list = CallbackList(
-            [SavingCallback(self, connector), LoggingCallback(connector), ResetInfoCallback(connector)]
+            [
+                SavingCallback(
+                    self, connector=connector, checkpoint_frequency=checkpoint_frequency, verbose=callback_verbosity
+                ),
+                LoggingCallback(
+                    connector=connector, logging_frequency=logging_frequency, log_distributions=log_distributions
+                ),
+                ResetInfoCallback(connector=connector),
+            ]
         )
         self.algorithm.learn(total_timesteps=total_timesteps, callback=callback_list)
         vectorized_environment.close()
@@ -314,6 +328,9 @@ class StableBaselinesAgent(RLAgent):
             algorithm_parameters (Dict): Parameter dictionary with filled up default parameter entries
 
         """
+        if not algorithm_parameters:
+            algorithm_parameters = {}
+
         if "policy" not in algorithm_parameters:
             algorithm_parameters.update({"policy": "MlpPolicy"})
 

--- a/src/rl_framework/agent/reinforcement/stable_baselines.py
+++ b/src/rl_framework/agent/reinforcement/stable_baselines.py
@@ -239,6 +239,7 @@ class StableBaselinesAgent(RLAgent):
         checkpoint_frequency = self.callback_parameters.get("checkpoint_frequency", 500000)
         log_distributions = self.callback_parameters.get("log_distributions", False)
         logging_frequency = self.callback_parameters.get("logging_frequency", 1)
+        sb3_logging_interval = self.callback_parameters.get("sb3_logging_interval", 1)
 
         callback_list = CallbackList(
             [
@@ -251,7 +252,7 @@ class StableBaselinesAgent(RLAgent):
                 ResetInfoCallback(connector=connector),
             ]
         )
-        self.algorithm.learn(total_timesteps=total_timesteps, callback=callback_list)
+        self.algorithm.learn(total_timesteps=total_timesteps, callback=callback_list, log_interval=sb3_logging_interval)
         vectorized_environment.close()
 
     def to_vectorized_env(self, env_fns, stub_env=None) -> VecEnv:

--- a/src/rl_framework/util/sb3_training_callbacks.py
+++ b/src/rl_framework/util/sb3_training_callbacks.py
@@ -127,7 +127,7 @@ class LoggingCallback(BaseCallback):
                 if self.locals["infos"][done_index].get("episode_end_reason", None) is not None:
                     if done_index not in self.episode_end_reasons:
                         self.episode_end_reasons[done_index] = deque(maxlen=100)
-                    self.episode_end_reasons.append(self.locals["infos"][done_index]["episode_end_reason"])
+                    self.episode_end_reasons[done_index].append(self.locals["infos"][done_index]["episode_end_reason"])
                     if log_this_episode:
                         counter = Counter(self.episode_end_reasons)
                         for reason, count in counter.items():

--- a/src/rl_framework/util/sb3_training_callbacks.py
+++ b/src/rl_framework/util/sb3_training_callbacks.py
@@ -25,7 +25,7 @@ class LoggingCallback(BaseCallback):
         - reason of episode end (provided as "episode_end_reason" in the info dict on terminated step)
     """
 
-    def __init__(self, connector, logging_frequency=10, log_distributions=False, verbose=0):
+    def __init__(self, connector, logging_frequency=1, log_distributions=False, verbose=0):
         """
         Args:
             verbose: Verbosity level: 0 for no output, 1 for info messages, 2 for debug messages

--- a/src/rl_framework/util/sb3_training_callbacks.py
+++ b/src/rl_framework/util/sb3_training_callbacks.py
@@ -25,18 +25,20 @@ class LoggingCallback(BaseCallback):
         - reason of episode end (provided as "episode_end_reason" in the info dict on terminated step)
     """
 
-    def __init__(self, connector, log_distributions=False, verbose=0):
+    def __init__(self, connector, logging_frequency=10, log_distributions=False, verbose=0):
         """
         Args:
             verbose: Verbosity level: 0 for no output, 1 for info messages, 2 for debug messages
         """
         super().__init__(verbose)
         self.connector = connector
+        self.logging_frequency = logging_frequency
         self.log_distributions = log_distributions
 
         # Tracking episode reward per episode
         #   (np.array, one index per agent, continuously updated by adding rewards at each step)
         self.episode_reward: Union[np.ndarray | None] = None
+        self.episode_rewards: dict[str, List[float]] = {}
         # Tracking actions per episode (one list per agent, updated by appending action at each step)
         # NOTE: Even though officially actions can be Any, for logging we assume they are int or float
         self.episode_actions: Union[List[List[Any]] | None] = None
@@ -44,7 +46,9 @@ class LoggingCallback(BaseCallback):
         self.episode_step_metrics: dict[str, List[List[float]]] = {}
 
         # Tracking stats across multiple episodes
-        self.episode_end_reasons = deque(maxlen=500)
+        self.episode_end_reasons: dict[str, Deque] = {}
+
+        self.episode_counter: dict[str, int] = {}
 
     def _on_step(self) -> bool:
         """
@@ -79,50 +83,62 @@ class LoggingCallback(BaseCallback):
         done_indices = np.where(self.locals["dones"] == True)[0]
         if done_indices.size != 0:
             for done_index in done_indices:
-                if not self.locals["infos"][done_index].get("discard", False):
-                    self.connector.log_value_with_timestep(
-                        self.num_timesteps, self.episode_reward[done_index], "Episode reward"
-                    )
-                    # Log other tracked step metrics
-                    for metric_name, per_agent_values in self.episode_step_metrics.items():
-                        if per_agent_values[done_index]:
-                            self.connector.log_value_with_timestep(
-                                self.num_timesteps,
-                                np.mean(per_agent_values[done_index]),
-                                value_name=f"Mean - {metric_name}",
-                                title_name=metric_name,
-                            )
-                            self.connector.log_value_with_timestep(
-                                self.num_timesteps,
-                                np.std(per_agent_values[done_index]),
-                                value_name=f"Std - {metric_name}",
-                                title_name=metric_name,
-                            )
-                            self.connector.log_value_with_timestep(
-                                self.num_timesteps,
-                                np.max(per_agent_values[done_index]),
-                                value_name=f"Max - {metric_name}",
-                                title_name=metric_name,
-                            )
-                            self.connector.log_value_with_timestep(
-                                self.num_timesteps,
-                                np.min(per_agent_values[done_index]),
-                                value_name=f"Min - {metric_name}",
-                                title_name=metric_name,
-                            )
+                self.episode_counter[done_index] = self.episode_counter.get(done_index, 0) + 1
+
+                if done_index not in self.episode_rewards:
+                    self.episode_rewards[done_index] = []
+                self.episode_rewards[done_index].append(self.episode_reward[done_index])
+
+                log_this_episode = self.episode_counter[done_index] % self.logging_frequency == 0
+
+                if log_this_episode:
+                    if not self.locals["infos"][done_index].get("discard", False):
+                        self.connector.log_value_with_timestep(
+                            self.num_timesteps, np.mean(self.episode_rewards[done_index]), "Episode reward"
+                        )
+                        # Log other tracked step metrics
+                        for metric_name, per_agent_values in self.episode_step_metrics.items():
+                            if per_agent_values[done_index]:
+                                self.connector.log_value_with_timestep(
+                                    self.num_timesteps,
+                                    np.mean(per_agent_values[done_index]),
+                                    value_name=f"Mean - {metric_name}",
+                                    title_name=metric_name,
+                                )
+                                self.connector.log_value_with_timestep(
+                                    self.num_timesteps,
+                                    np.std(per_agent_values[done_index]),
+                                    value_name=f"Std - {metric_name}",
+                                    title_name=metric_name,
+                                )
+                                self.connector.log_value_with_timestep(
+                                    self.num_timesteps,
+                                    np.max(per_agent_values[done_index]),
+                                    value_name=f"Max - {metric_name}",
+                                    title_name=metric_name,
+                                )
+                                self.connector.log_value_with_timestep(
+                                    self.num_timesteps,
+                                    np.min(per_agent_values[done_index]),
+                                    value_name=f"Min - {metric_name}",
+                                    title_name=metric_name,
+                                )
 
                 if self.locals["infos"][done_index].get("episode_end_reason", None) is not None:
+                    if done_index not in self.episode_end_reasons:
+                        self.episode_end_reasons[done_index] = deque(maxlen=100)
                     self.episode_end_reasons.append(self.locals["infos"][done_index]["episode_end_reason"])
-                    counter = Counter(self.episode_end_reasons)
-                    for reason, count in counter.items():
-                        self.connector.log_value_with_timestep(
-                            self.num_timesteps,
-                            count / len(self.episode_end_reasons),
-                            value_name=f"Episode end reason - {reason}",
-                            title_name="Episode end reasons",
-                        )
+                    if log_this_episode:
+                        counter = Counter(self.episode_end_reasons)
+                        for reason, count in counter.items():
+                            self.connector.log_value_with_timestep(
+                                self.num_timesteps,
+                                count / len(self.episode_end_reasons[done_index]),
+                                value_name=f"Episode end reason - {reason}",
+                                title_name="Episode end reasons",
+                            )
 
-                if self.log_distributions:
+                if self.log_distributions and log_this_episode:
                     # Log action distribution
                     if self.episode_actions[done_index]:
                         if isinstance(self.episode_actions[done_index][0], np.ndarray):
@@ -148,10 +164,12 @@ class LoggingCallback(BaseCallback):
 
                 # Reset trackers for done agent
                 self.episode_reward[done_index] = 0
-                for metric_name in self.episode_step_metrics.keys():
-                    self.episode_step_metrics[metric_name][done_index] = []
-                if self.episode_actions:
-                    self.episode_actions[done_index] = []
+                if log_this_episode:
+                    self.episode_rewards[done_index] = []
+                    for metric_name in self.episode_step_metrics.keys():
+                        self.episode_step_metrics[metric_name][done_index] = []
+                    if self.episode_actions:
+                        self.episode_actions[done_index] = []
 
         return True
 

--- a/src/rl_framework/util/sb3_training_callbacks.py
+++ b/src/rl_framework/util/sb3_training_callbacks.py
@@ -129,7 +129,7 @@ class LoggingCallback(BaseCallback):
                         self.episode_end_reasons[done_index] = deque(maxlen=100)
                     self.episode_end_reasons[done_index].append(self.locals["infos"][done_index]["episode_end_reason"])
                     if log_this_episode:
-                        counter = Counter(self.episode_end_reasons)
+                        counter = Counter(self.episode_end_reasons[done_index])
                         for reason, count in counter.items():
                             self.connector.log_value_with_timestep(
                                 self.num_timesteps,


### PR DESCRIPTION
`StableBaselinesAgent` now can take in config a "callback_kwargs" parameter, as a dict.

Currently supported dict keys:
"callback_verbosity": 0 or 1
"checkpoint_frequency": saving frequency, default 500000
"log_distributions": whether to log action/metric distribution, default False
"logging_frequency": log episode metrics aggregated over N episode, default 1