### PR TITLE
Suppress gym warning on SB3 import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "reinforcement-learning-framework"
-version = "0.9.16"
+version = "0.9.17"
 description = "An easy-to-read Reinforcement Learning (RL) framework. Provides standardized interfaces and implementations to various Reinforcement Learning methods and utilities."
 homepage = "https://github.com/alexander-zap/reinforcement-learning-framework"
 authors = ["Alexander Zap"]

--- a/src/rl_framework/util/types.py
+++ b/src/rl_framework/util/types.py
@@ -1,8 +1,13 @@
+import contextlib
+import io
 from typing import Callable, List, Union
 
 import gymnasium as gym
 from pettingzoo import ParallelEnv
-from stable_baselines3.common.vec_env import VecEnv
+
+# Suppress gym deprecation warning during import (safety measure)
+with contextlib.redirect_stderr(io.StringIO()):
+    from stable_baselines3.common.vec_env import VecEnv
 
 # Tuple of
 #   - gymnasium.Env (stub env, defining observation and action space)


### PR DESCRIPTION
This warning comes from d3rlpy library installing `gym` (without any further usage) and then SB3 warning about it.